### PR TITLE
Fixed link rendering issues.

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1235,24 +1235,6 @@ function marked(src, opt, callback) {
     extractUrlsWithoutProtocol: true
   });
 
-  var code_blocks_before_link_rendering = src.match(/`{1}[\s\S]*?`{1}/g);
-
-  sourceWithRenderedLinks = twttr.txt.autoLinkEntities(src, entities);
-  sourceWithRenderedLinks = sourceWithRenderedLinks.replace(/&amp;amp;/g, '&amp;');
-  sourceWithRenderedLinks = sourceWithRenderedLinks.replace(/rel="nofollow"/gi, 'target="_blank" rel="nofollow noopener noreferrer"');
-
-  src = sourceWithRenderedLinks;
-
-  var code_blocks_after_link_rendering = src.match(/`{1}[\s\S]*?`{1}/g);
-
-  if(code_blocks_before_link_rendering && code_blocks_after_link_rendering) {
-    if(code_blocks_before_link_rendering.length === code_blocks_after_link_rendering.length) {
-      for(var i in code_blocks_after_link_rendering) {
-        src = src.replace(code_blocks_after_link_rendering[i], code_blocks_before_link_rendering[i]);
-      }
-    }
-  }
-
   try {
     if (opt) opt = merge({}, marked.defaults, opt);
     return Parser.parse(Lexer.lex(src, opt), opt);


### PR DESCRIPTION
This resolves an issue in the webapp and the desktop apps that causes links to be rendered incorrectly. Marked already has link handling, so I'm unsure why this snippet was added in the first place.

(Copied directly from Chrome Inspector)

Before:
```
[test](https://google.com)
```
```
<a href="a href=&quot;https://google.com&quot; target=&quot;_blank&quot; rel=&quot;nofollow noopener noreferrer&quot;&gt;https://google.com&lt;/a" target="_blank" rel="nofollow noopener noreferrer">test</a>
```
After
```
[test](https://google.com)
```
```
<a href="https://google.com" target="_blank" rel="nofollow noopener noreferrer">test</a>
```