### PR TITLE
Replace twitter-text with linkify

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1230,15 +1230,9 @@ function marked(src, opt, callback) {
   // Preserve backticks for code statements
   src = src.replace(/&#x60;/g, '`');
 
-  // Parse links in input with linkifyjs library
-  src = linkifyHtml(src, {ignoreTags: ['code', 'pre'], attributes: { rel: 'nofollow noopener noreferrer' }});
-
-  // Remove this when this is merged: https://github.com/SoapBox/linkifyjs/pull/189
-  src = src.replace(/ class="linkified"/g, '');
-
   try {
     if (opt) opt = merge({}, marked.defaults, opt);
-    return Parser.parse(Lexer.lex(src, opt), opt);
+    src = Parser.parse(Lexer.lex(src, opt), opt);
   } catch (e) {
     e.message += '\nPlease report this to https://github.com/chjj/marked.';
     if ((opt || marked.defaults).silent) {
@@ -1248,6 +1242,14 @@ function marked(src, opt, callback) {
     }
     throw e;
   }
+
+  // Parse links in input with linkifyjs library
+  src = linkifyHtml(src, {ignoreTags: ['code', 'pre'], attributes: { rel: 'nofollow noopener noreferrer' }});
+
+  // Remove this when this is merged: https://github.com/SoapBox/linkifyjs/pull/189
+  src = src.replace(/ class="linkified"/g, '');
+
+  return src;
 }
 
 /**

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1230,28 +1230,8 @@ function marked(src, opt, callback) {
   // Preserve backticks for code statements
   src = src.replace(/&#x60;/g, '`');
 
-  // Parse links in input with Twitter library
-  var entities = twttr.txt.extractUrlsWithIndices(src, {
-    extractUrlsWithoutProtocol: true
-  });
-
-  var code_blocks_before_link_rendering = src.match(/`{1}[\s\S]*?`{1}/g);
-
-  sourceWithRenderedLinks = twttr.txt.autoLinkEntities(src, entities);
-  sourceWithRenderedLinks = sourceWithRenderedLinks.replace(/&amp;amp;/g, '&amp;');
-  sourceWithRenderedLinks = sourceWithRenderedLinks.replace(/rel="nofollow"/gi, 'target="_blank" rel="nofollow noopener noreferrer"');
-
-  src = sourceWithRenderedLinks;
-
-  var code_blocks_after_link_rendering = src.match(/`{1}[\s\S]*?`{1}/g);
-
-  if(code_blocks_before_link_rendering && code_blocks_after_link_rendering) {
-    if(code_blocks_before_link_rendering.length === code_blocks_after_link_rendering.length) {
-      for(var i in code_blocks_after_link_rendering) {
-        src = src.replace(code_blocks_after_link_rendering[i], code_blocks_before_link_rendering[i]);
-      }
-    }
-  }
+  // Parse links in input with linkifyjs library
+  src = linkifyHtml({attributes: { rel: 'nofollow noopener noreferrer' }});
 
   try {
     if (opt) opt = merge({}, marked.defaults, opt);

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1231,7 +1231,7 @@ function marked(src, opt, callback) {
   src = src.replace(/&#x60;/g, '`');
 
   // Parse links in input with linkifyjs library
-  src = linkifyHtml(src, {attributes: { rel: 'nofollow noopener noreferrer' }});
+  src = linkifyHtml(src, {ignoreTags: ['code', 'pre'], attributes: { rel: 'nofollow noopener noreferrer' }});
 
   // Remove this when this is merged: https://github.com/SoapBox/linkifyjs/pull/189
   src = src.replace(/ class="linkified"/g, '');

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1232,7 +1232,7 @@ function marked(src, opt, callback) {
 
   try {
     if (opt) opt = merge({}, marked.defaults, opt);
-    src = Parser.parse(Lexer.lex(src, opt), opt);
+    return Parser.parse(Lexer.lex(src, opt), opt);
   } catch (e) {
     e.message += '\nPlease report this to https://github.com/chjj/marked.';
     if ((opt || marked.defaults).silent) {
@@ -1242,14 +1242,6 @@ function marked(src, opt, callback) {
     }
     throw e;
   }
-
-  // Parse links in input with linkifyjs library
-  src = linkifyHtml(src, {validate: { email: function (value) { return false; } }, ignoreTags: ['code', 'pre'], attributes: { rel: 'nofollow noopener noreferrer' }});
-
-  // Remove this when this is merged: https://github.com/SoapBox/linkifyjs/pull/189
-  src = src.replace(/ class="linkified"/g, '');
-
-  return src;
 }
 
 /**

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1244,7 +1244,7 @@ function marked(src, opt, callback) {
   }
 
   // Parse links in input with linkifyjs library
-  src = linkifyHtml(src, {ignoreTags: ['code', 'pre'], attributes: { rel: 'nofollow noopener noreferrer' }});
+  src = linkifyHtml(src, {validate: { email: function (value) { return false; } }, ignoreTags: ['code', 'pre'], attributes: { rel: 'nofollow noopener noreferrer' }});
 
   // Remove this when this is merged: https://github.com/SoapBox/linkifyjs/pull/189
   src = src.replace(/ class="linkified"/g, '');

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1231,7 +1231,7 @@ function marked(src, opt, callback) {
   src = src.replace(/&#x60;/g, '`');
 
   // Parse links in input with linkifyjs library
-  src = linkifyStr({attributes: { rel: 'nofollow noopener noreferrer' }});
+  src = linkifyHtml(src, {attributes: { rel: 'nofollow noopener noreferrer' }});
 
   try {
     if (opt) opt = merge({}, marked.defaults, opt);

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1233,6 +1233,9 @@ function marked(src, opt, callback) {
   // Parse links in input with linkifyjs library
   src = linkifyHtml(src, {attributes: { rel: 'nofollow noopener noreferrer' }});
 
+  // Remove this when this is merged: https://github.com/SoapBox/linkifyjs/pull/189
+  src = src.replace(/ class="linkify"/g, '');
+
   try {
     if (opt) opt = merge({}, marked.defaults, opt);
     return Parser.parse(Lexer.lex(src, opt), opt);

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1234,7 +1234,7 @@ function marked(src, opt, callback) {
   src = linkifyHtml(src, {attributes: { rel: 'nofollow noopener noreferrer' }});
 
   // Remove this when this is merged: https://github.com/SoapBox/linkifyjs/pull/189
-  src = src.replace(/ class="linkify"/g, '');
+  src = src.replace(/ class="linkified"/g, '');
 
   try {
     if (opt) opt = merge({}, marked.defaults, opt);

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1231,7 +1231,7 @@ function marked(src, opt, callback) {
   src = src.replace(/&#x60;/g, '`');
 
   // Parse links in input with linkifyjs library
-  src = linkifyHtml({attributes: { rel: 'nofollow noopener noreferrer' }});
+  src = linkifyStr({attributes: { rel: 'nofollow noopener noreferrer' }});
 
   try {
     if (opt) opt = merge({}, marked.defaults, opt);


### PR DESCRIPTION
Replace twitter-text library with linkify to introduce following improvements over twitter-text:
* URLs with IP addresses are displayed as links
* localhost addresses are displayed as link
* No rendering of links in 'code' markdown

The library is much smaller and very fast:
See https://github.com/SoapBox/linkifyjs#features

**Attention:** This needs to be merged together with the wire-webapp PR